### PR TITLE
Support Cargo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.1.0
+Now we support Cargo!
+
 # 0.0.3
 Check original file, not a tmp copy. See #1.
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # linter-rust
 
-This package will lint your Rust-files in Atom, using [rustc](http://www.rust-lang.org).
+This package will lint your Rust-files in Atom, using [rustc](http://www.rust-lang.org) and [cargo](https://crates.io).
 Files will be checked when you open or save them.
 
 ## Installation
 
-* Install [Rust](http://www.rust-lang.org).
+* Install [Rust](http://www.rust-lang.org) and/or [Cargo](https://crates.io).
 * `$ apm install linter` (if you don't have [AtomLinter/Linter](https://github.com/AtomLinter/Linter) installed).
 * `$ apm install linter-rust`
 

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -3,7 +3,11 @@ module.exports =
     executablePath:
       type: 'string'
       default: 'rustc'
-      description: 'Path to rust compiller.'
+      description: 'Path to rust compiler'
+    executablePath2:
+      type: 'string'
+      default: 'cargo'
+      description: 'Path to rust package manager'
 
   activate: ->
     console.log 'Linter-Rust: package loaded,

--- a/lib/linter-rust.coffee
+++ b/lib/linter-rust.coffee
@@ -45,7 +45,7 @@ class LinterRust extends Linter
       @cmd = "cargo build"
       @cwd = path.dirname @cargoManifestPath
     else
-      @cmd = "rustc --no-trans --color never"
+      @cmd = "rustc -Z no-trans --color never"
       @cwd = path.dirname editing_file
 
   lintFile: (filePath, callback) =>

--- a/lib/linter-rust.coffee
+++ b/lib/linter-rust.coffee
@@ -13,7 +13,7 @@ class LinterRust extends Linter
   @cargoManifestPath: null
   linterName: 'rust'
   errorStream: 'stderr'
-  regex: '^(.+):(?<line>\\d+):(?<col>\\d+):\\s*(\\d+):(\\d+)\\s+((?<error>error|fatal error)|(?<warning>warning)):\\s+(?<message>.+)\n'
+  regex: '^(?<file>.+):(?<line>\\d+):(?<col>\\d+):\\s*(\\d+):(\\d+)\\s+((?<error>error|fatal error)|(?<warning>warning)):\\s+(?<message>.+)\n'
 
   constructor: (@editor) ->
     super @editor

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "linter-package": true,
   "activationEvents": [],
   "main": "./lib/init",
-  "version": "0.0.3",
-  "description": "Lint Rust on the fly, using rustc",
+  "version": "0.1.0",
+  "description": "Lint Rust on the fly, using rustc and cargo",
   "repository": "https://github.com/AtomLinter/linter-rust",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
This PR add the support of Cargo to Rust Linter. We try to find file `Cargo.toml` first, to decide which we should use it to lint the source file, `cargo` (if we found a `Cargo.toml`) or `rustc` (if not found). Both rustc and cargo's path are configurable.

We also need to improve [Linter repo](https://github.com/AtomLinter/Linter) to complete this work. Currently, blocked by https://github.com/AtomLinter/Linter/pull/290 and https://github.com/AtomLinter/Linter/pull/304. These two PRs of mine are under reviewing.

Closes #4

update: 
one limitation: when lint using cargo, you must save the editing file first. it is too expensive to copy the full cargo package to tmp directory, imo.