### PR TITLE
Correct regex string

### DIFF
--- a/lib/linter-rust.coffee
+++ b/lib/linter-rust.coffee
@@ -11,7 +11,7 @@ class LinterRust extends Linter
   @syntax: 'source.rust'
   linterName: 'rust'
   errorStream: 'stderr'
-  regex: '^(.+):(?<line>\\d+):(?<col>\\d+):\\s*(\\d+):(\\d+)\\s+((?<error>error|fatal error)|(?<warning>warning)):\\s+(?<message>.+)\n'
+  regex: '(.+):(?<line>\\d+):(?<col>\\d+):\\s*(\\d+):(\\d+)\\s+((?<error>error|fatal error)|(?<warning>warning)):\\s+(?<message>.+)\n'
 
   constructor: (@editor) ->
     super @editor


### PR DESCRIPTION
Previously it only matched on the first error, and only if the first rustc output was an error.