### PR TITLE
'extern crate' problem

### DIFF
--- a/lib/linter-rust.coffee
+++ b/lib/linter-rust.coffee
@@ -50,8 +50,8 @@ class LinterRust extends Linter
 
   lintFile: (filePath, callback) =>
     if @enabled
-      @filePath = path.basename do @editor.getPath
-      super @filePath, callback
+      origin_file = path.basename do @editor.getPath
+      super origin_file, callback
 
   locateCargo: ->
     directory = path.resolve path.dirname do @editor.getPath


### PR DESCRIPTION
### Problem
'extern crate' directive cause error because rustc cannot resolve additional dependencies.

### Solution
* We try to locate Cargo.toml file in every parent directory recursively
* If we reached root directory and the file is not found - there is nothing we can do, so linter keep working as before
* If we found Cargo.toml in some directory, we assume it as a project root, and pass that_dir/target/debug/deps directory to rustc library lookup path
* Then, after debug build, rustc can resolve dependencies and linter works fine