### PR TITLE
Add Rust home path configuration option.

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -1,13 +1,9 @@
 module.exports =
   config:
-    executablePath:
+    rustHome:
       type: 'string'
-      default: 'rustc'
-      description: 'Path to rust compiller'
-    cargoExecutablePath:
-      type: 'string'
-      default: 'cargo'
-      description: 'Path to Cargo package manager'
+      default: '/usr/local'
+      description: 'Path to Rust\'s home directory. rustc should exist in /bin/rustc from here.'
     useCargo:
       type: 'boolean'
       default: true


### PR DESCRIPTION
This replaces the previous direct executable path options for something more flexible and future-proof when checking for Cargo and rustc.

Fixes #12.

The given path is prepended to the executable in the child_process.spawn options. This ensures that the execution environment is as-expected for compiling rust programs with cargo (i.e. rustc can be found). This is tested on Windows but should work without configuration on Linux and Mac where Rust is installed to /usr/local. This also makes it easier to switch between multiple installations of Rust (i.e. stable, nightly) for linting.

Strangely, when using the Cargo option, the entire project being linted may be built in the background, which can take a very long time.