### PR TITLE
Use explicit path to rusts executables

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -5,15 +5,15 @@ module.exports =
     rustcPath:
       type: 'string'
       default: 'rustc'
-      description: 'Path to Rust\'s compiler `rustc`.'
+      description: "Path to Rust's compiler `rustc`."
     cargoPath:
       type: 'string'
       default: 'cargo'
-      description: 'Path to Rust\'s package manager `cargo`.'
+      description: "Path to Rust's package manager `cargo`."
     useCargo:
       type: 'boolean'
       default: true
-      description: 'Use Cargo if it\'s possible'
+      description: "Use Cargo if it's possible"
     cargoManifestFilename:
       type: 'string'
       default: 'Cargo.toml'
@@ -39,24 +39,20 @@ module.exports =
       Please install https://github.com/zargony/atom-language-rust'
 
     @subscriptions = new CompositeDisposable
-    @subscriptions.add atom.config.observe 'linter-rust.rustcPath',
-    (rustcPath) =>
+
+    @subscriptions.add atom.config.observe 'linter-rust.rustcPath', (rustcPath) =>
       @rustcPath = rustcPath
 
-    @subscriptions.add atom.config.observe 'linter-rust.cargoPath',
-    (cargoPath) =>
+    @subscriptions.add atom.config.observe 'linter-rust.cargoPath', (cargoPath) =>
       @cargoPath = cargoPath
 
-    @subscriptions.add atom.config.observe 'linter-rust.useCargo',
-    (useCargo) =>
+    @subscriptions.add atom.config.observe 'linter-rust.useCargo', (useCargo) =>
       @useCargo = useCargo
 
-    @subscriptions.add atom.config.observe 'linter-rust.cargoManifestFilename',
-    (cargoManifestFilename) =>
+    @subscriptions.add atom.config.observe 'linter-rust.cargoManifestFilename', (cargoManifestFilename) =>
       @cargoManifestFilename = cargoManifestFilename
 
-    @subscriptions.add atom.config.observe 'linter-rust.jobsNumber',
-    (jobsNumber) =>
+    @subscriptions.add atom.config.observe 'linter-rust.jobsNumber', (jobsNumber) =>
       @jobsNumber = jobsNumber
 
   deactivate: ->
@@ -64,11 +60,11 @@ module.exports =
 
 
   provideLinter: ->
-      LinterRust = require('./linter-rust')
-      @provider = new LinterRust()
-      return {
-        grammarScopes: ['source.rust']
-        scope: 'project'
-        lint: @provider.lint
-        lintOnFly: false
-      }
+    LinterRust = require('./linter-rust')
+    @provider = new LinterRust()
+    return {
+      grammarScopes: ['source.rust']
+      scope: 'project'
+      lint: @provider.lint
+      lintOnFly: false
+    }

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -2,10 +2,14 @@
 
 module.exports =
   config:
-    rustHome:
+    rustcPath:
       type: 'string'
-      default: '/usr/local'
-      description: 'Path to Rust\'s home directory. rustc should exist in /bin/rustc from here.'
+      default: 'rustc'
+      description: 'Path to Rust\'s compiler `rustc`.'
+    cargoPath:
+      type: 'string'
+      default: 'cargo'
+      description: 'Path to Rust\'s package manager `cargo`.'
     useCargo:
       type: 'boolean'
       default: true
@@ -35,9 +39,13 @@ module.exports =
       Please install https://github.com/zargony/atom-language-rust'
 
     @subscriptions = new CompositeDisposable
-    @subscriptions.add atom.config.observe 'linter-rust.rustHome',
-    (rustHome) =>
-      @rustHome = rustHome
+    @subscriptions.add atom.config.observe 'linter-rust.rustcPath',
+    (rustcPath) =>
+      @rustcPath = rustcPath
+
+    @subscriptions.add atom.config.observe 'linter-rust.cargoPath',
+    (cargoPath) =>
+      @cargoPath = cargoPath
 
     @subscriptions.add atom.config.observe 'linter-rust.useCargo',
     (useCargo) =>

--- a/lib/linter-rust.coffee
+++ b/lib/linter-rust.coffee
@@ -1,7 +1,8 @@
 fs = require 'fs'
 path = require 'path'
 {BufferedProcess} = require 'atom'
-XRegExp = require('xregexp').XRegExp
+{spawn} = require 'child_process'
+{XRegExp} = require 'xregexp'
 
 
 class LinterRust
@@ -57,10 +58,9 @@ class LinterRust
 
   initCmd: (editingFile) =>
     cargoManifestPath = @locateCargo path.dirname editingFile
-    rustHome = @config 'rustHome'
-    rustcPath = path.join rustHome, 'bin', 'rustc'
-    cargoPath = path.join rustHome, 'bin', 'cargo'
-    if not cargoPath or not @config('useCargo') or not cargoManifestPath
+    rustcPath = @config 'rustcPath'
+    cargoPath = @config 'cargoPath'
+    if not @config('useCargo') or not cargoManifestPath
       @cmd = [rustcPath, '-Z', 'no-trans', '--color', 'never']
       if cargoManifestPath
         @cmd.push '-L'

--- a/lib/linter-rust.coffee
+++ b/lib/linter-rust.coffee
@@ -1,7 +1,6 @@
 fs = require 'fs'
 path = require 'path'
 {BufferedProcess} = require 'atom'
-{spawn} = require 'child_process'
 {XRegExp} = require 'xregexp'
 
 
@@ -26,8 +25,10 @@ class LinterRust
       exit = (code) ->
         return resolve [] unless code is 101 or code is 0
         messages = []
-        regex = XRegExp('(?<file>.+):(?<line>\\d+):(?<col>\\d+):\\s*(\\d+):(\\d+)\\s+((?<error>error|fatal error)|(?<warning>warning)|(?<info>note)):\\s+(?<message>.+)\n', '')
-        XRegExp.forEach results.join(''), regex, (match) =>
+        regex = XRegExp('(?<file>.+):(?<line>\\d+):(?<col>\\d+):\\s*(\\d+):(\\d+)\\s+\
+          ((?<error>error|fatal error)|(?<warning>warning)|(?<info>note)):\\s+\
+          (?<message>.+)\n', '')
+        XRegExp.forEach results.join(''), regex, (match) ->
           type = if match.error
             "Error"
           else if match.warning
@@ -53,7 +54,7 @@ class LinterRust
 
 
   config: (key) ->
-      atom.config.get "linter-rust.#{key}"
+    atom.config.get "linter-rust.#{key}"
 
 
   initCmd: (editingFile) =>


### PR DESCRIPTION
This way we don't make any assumption on the installation of rust.
Additionally, the default values provide a flawless setup on properly
configured Windows, Linux and OSX boxes.