### PR TITLE
Move parsing into dedicated method for testability

### DIFF
--- a/lib/linter-rust.coffee
+++ b/lib/linter-rust.coffee
@@ -47,7 +47,6 @@ class LinterRust
 
   parse: (output) =>
     messages = []
-
     XRegExp.forEach output, @pattern, (match) ->
       type = if match.error
         "Error"
@@ -55,7 +54,7 @@ class LinterRust
         "Warning"
 
       if match.from_col == match.to_col
-        match.to_col += 1
+        match.to_col = parseInt(match.to_col) + 1
 
       messages.push {
         type: type or 'Warning'
@@ -66,7 +65,6 @@ class LinterRust
           [match.to_line - 1, match.to_col - 1]
         ]
       }
-
     return messages
 
   config: (key) ->

--- a/spec/parse-spec.coffee
+++ b/spec/parse-spec.coffee
@@ -1,0 +1,41 @@
+LinterRust = require '../lib/linter-rust'
+
+linter = new LinterRust()
+
+describe "LinterRust::parse", ->
+  it "should return 0 messages for an empty string", ->
+    expect(linter.parse('')).toEqual([])
+
+  it "should properly parse one line error message", ->
+    expect(linter.parse('my/awesome file.rs:1:2: 3:4 error: my awesome text\n'))
+      .toEqual([{
+        type: 'Error'
+        text: 'my awesome text'
+        filePath: 'my/awesome file.rs'
+        range: [[0, 1], [2, 3]]
+      }])
+
+  it "should properly parse one line warning message", ->
+    expect(linter.parse('foo:33:44: 22:33 warning: äüö<>\n'))
+      .toEqual([{
+        type: 'Warning',
+        text: 'äüö<>'
+        filePath: 'foo'
+        range: [[32, 43], [21, 32]]
+      }])
+
+  it "should return messages with a range of at least one character", ->
+    expect(linter.parse('foo:1:1: 1:1 error: text\n'))
+      .toEqual([{
+        type: 'Error'
+        text: 'text'
+        filePath: 'foo'
+        range: [[0, 0], [0, 1]]
+      }])
+    expect(linter.parse('foo:1:1: 2:1 error: text\n'))
+      .toEqual([{
+        type: 'Error'
+        text: 'text'
+        filePath: 'foo'
+        range: [[0, 0], [1, 1]]
+      }])


### PR DESCRIPTION
This PR contains a little refactoring, a bug fix and the addition of a first spec to test the parsing of the linting tool (`rustc`/`cargo`) output.
Furthermore, this should be the basis to fix bugs like #22 and to prevent regressions.