### PR TITLE
Support multiline lint messages

### DIFF
--- a/lib/linter-rust.coffee
+++ b/lib/linter-rust.coffee
@@ -7,10 +7,10 @@ path = require 'path'
 class LinterRust
   cargoDependencyDir: "target/debug/deps"
   lintProcess: null
-  pattern: XRegExp('(?<file>.+):(?<from_line>\\d+):(?<from_col>\\d+):\\s*\
+  pattern: XRegExp('(?<file>[^\n\r]+):(?<from_line>\\d+):(?<from_col>\\d+):\\s*\
     (?<to_line>\\d+):(?<to_col>\\d+)\\s+\
     ((?<error>error|fatal error)|(?<warning>warning)|(?<info>note)):\\s+\
-    (?<message>.+)\n', '')
+    (?<message>.+?)[\n\r]+($|(?=[^\n\r]+:\\d+))', 's')
 
   lint: (textEditor) =>
     return new Promise (resolve, reject) =>

--- a/spec/parse-spec.coffee
+++ b/spec/parse-spec.coffee
@@ -60,3 +60,11 @@ describe "LinterRust::parse", ->
       .toEqual([
         { type: 'Error', text: 'line one\ntwo\nthree', filePath: 'bar', range: [[0, 1], [2, 3]] }
       ])
+
+  it "should also cope with windows line breaks", ->
+    expect(linter.parse('a:1:2: 3:4 error: a\r\nb\n')[0].text)
+      .toEqual('a\r\nb')
+
+    multi = linter.parse('a:1:2: 3:4 error: a\n\rb\n\rx:1:2: 3:4 error: asd\r\n')
+    expect(multi[0].text).toEqual('a\n\rb')
+    expect(multi[1].text).toEqual('asd')

--- a/spec/parse-spec.coffee
+++ b/spec/parse-spec.coffee
@@ -39,3 +39,24 @@ describe "LinterRust::parse", ->
         filePath: 'foo'
         range: [[0, 0], [1, 1]]
       }])
+
+  it "should properly parse multiline messages", ->
+    expect(linter.parse('bar:1:2: 3:4 error: line one\n\
+                         two\n'))
+      .toEqual([
+        { type: 'Error', text: 'line one\ntwo', filePath: 'bar', range: [[0, 1], [2, 3]] }
+      ])
+    expect(linter.parse('bar:1:2: 3:4 error: line one\n\
+                         two\n\
+                         foo:1:1: 1:2 warning: simple line\n'))
+      .toEqual([
+        { type: 'Error', text: 'line one\ntwo', filePath: 'bar', range: [[0, 1], [2, 3]] },
+        { type: 'Warning', text: 'simple line', filePath: 'foo', range: [[0, 0], [0, 1]] }
+      ])
+    expect(linter.parse('bar:1:2: 3:4 error: line one\n\
+                         two\n\
+                         three\n\
+                         foo:1   shouldnt match'))
+      .toEqual([
+        { type: 'Error', text: 'line one\ntwo\nthree', filePath: 'bar', range: [[0, 1], [2, 3]] }
+      ])


### PR DESCRIPTION
This PR adds support for multiline lint messages, e.g., type error messages. Additionally, it ensures that Unix and Windows line breaks are properly supported.
Tests were added for both fixes.

Fixes #22 