### PR TITLE
Fix #36

### DIFF
--- a/lib/linter-rust.coffee
+++ b/lib/linter-rust.coffee
@@ -22,7 +22,6 @@ class LinterRust
       options.cwd = curDir
       @cmd.push file
       command = @cmd[0]
-      options = {cwd: curDir}
       args = @cmd.slice 1
 
       stdout = (data) ->

--- a/lib/linter-rust.coffee
+++ b/lib/linter-rust.coffee
@@ -17,6 +17,9 @@ class LinterRust
       results = []
       file = @initCmd do textEditor.getPath
       curDir = path.dirname file
+      PATH = path.dirname @cmd[0]
+      options = @makeOpts(PATH)
+      options.cwd = curDir
       @cmd.push file
       command = @cmd[0]
       options = {cwd: curDir}
@@ -108,6 +111,17 @@ class LinterRust
       directory = path.resolve path.join(directory, '..')
     return false
 
+  makeOpts: (PATH) ->
+    options = process.env;
 
+    switch process.platform
+      when "darwin" || "linux"
+        delim = ":"
+        options.PATH = "/usr/local/bin" + delim + PATH
+      when "win32"
+        delim = ";"
+        options.Path = "/usr/local/bin" + delim + PATH
+
+    options
 
 module.exports = LinterRust

--- a/lib/linter-rust.coffee
+++ b/lib/linter-rust.coffee
@@ -116,11 +116,9 @@ class LinterRust
 
     switch process.platform
       when "darwin" || "linux"
-        delim = ":"
-        options.PATH = "/usr/local/bin" + delim + PATH
+        options.PATH = PATH + path.delimiter + options.PATH
       when "win32"
-        delim = ";"
-        options.Path = "/usr/local/bin" + delim + PATH
+        options.Path = PATH + path.delimiter + options.Path
 
     options
 

--- a/lib/linter-rust.coffee
+++ b/lib/linter-rust.coffee
@@ -18,7 +18,8 @@ class LinterRust
       file = @initCmd do textEditor.getPath
       curDir = path.dirname file
       PATH = path.dirname @cmd[0]
-      options = @makeOpts(PATH)
+      options = process.env;
+      options.PATH = PATH + path.delimiter + options.PATH
       options.cwd = curDir
       @cmd.push file
       command = @cmd[0]
@@ -109,16 +110,5 @@ class LinterRust
       break if root_dir.test directory
       directory = path.resolve path.join(directory, '..')
     return false
-
-  makeOpts: (PATH) ->
-    options = process.env;
-
-    switch process.platform
-      when "darwin" || "linux"
-        options.PATH = PATH + path.delimiter + options.PATH
-      when "win32"
-        options.Path = PATH + path.delimiter + options.Path
-
-    options
 
 module.exports = LinterRust


### PR DESCRIPTION
This adds the parent directory of the rustc installation to the PATH of the
spawned command. Otherwise cargo does not know where rustc is installed.