### PR TITLE
Add name for the linter

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -70,6 +70,7 @@ module.exports =
     LinterRust = require('./linter-rust')
     @provider = new LinterRust()
     return {
+      name: 'Rust'
       grammarScopes: ['source.rust']
       scope: 'project'
       lint: @provider.lint


### PR DESCRIPTION
`ESLint` appears to do this so it can show in the UI when using multiple linters:

https://github.com/AtomLinter/linter-eslint/blob/704fa7b3b9bec75bdd59a8377b51790cc511f031/lib/linter-eslint.coffee#L44