### PR TITLE
Add option to use "cargo rustc" instead of "cargo build"

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -14,6 +14,12 @@ module.exports =
       type: 'boolean'
       default: true
       description: "Use Cargo if it's possible"
+    useRustcNotrans:
+      type: 'boolean'
+      default: false
+      description: "Use 'cargo rustc -Zno-trans' instead of 'cargo build' to
+        lint.  Faster, but does not build the project.  Cargo must be enabled.
+        Does not apply to test code."
     buildTest:
       type: 'boolean'
       default: false

--- a/lib/linter-rust.coffee
+++ b/lib/linter-rust.coffee
@@ -97,7 +97,10 @@ class LinterRust
       if @config('buildTest')
         @cmd = [cargoPath, 'test', '--no-run', '-j', @config('jobsNumber'), '--manifest-path']
       else
-        @cmd = [cargoPath, 'build', '-j', @config('jobsNumber'), '--manifest-path']
+        if @config('useRustcNotrans')
+          @cmd = [cargoPath, 'rustc', '-Zno-trans', '--color', 'never', '-j', @config('jobsNumber'), '--manifest-path']
+        else
+          @cmd = [cargoPath, 'build', '-j', @config('jobsNumber'), '--manifest-path']
       return cargoManifestPath
 
 


### PR DESCRIPTION
This adds an option to use `cargo rustc` instead of `cargo build`.

In my experience, `cargo rustc` is faster for lints and error checking, and since it doesn't build, it does not interfere with builds triggered from elsewhere (e.g. a terminal window).  

Partial fix for #29, possibly #16 