### PR TITLE
Add choice to use clippy for linting

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -21,9 +21,11 @@ module.exports =
     cargoCommand:
       type: 'string'
       default: 'build'
-      enum: ['build', 'check', 'test', 'rustc']
+      enum: ['build', 'check', 'test', 'rustc', 'clippy']
       description: "Use 'check' for fast linting (you need to install
-        `cargo-check`). Use 'test' to lint test code, too.
+        `cargo-check`). Use 'clippy' to increase amount of available lints
+        (you need to install `cargo-clippy`). 
+        Use 'test' to lint test code, too.
         Use 'rustc' for fast linting (note: does not build
         the project)."
     cargoManifestFilename:

--- a/lib/linter-rust.coffee
+++ b/lib/linter-rust.coffee
@@ -91,6 +91,7 @@ class LinterRust
       when 'check' then ['check']
       when 'test' then ['test', '--no-run']
       when 'rustc' then ['rustc', '-Zno-trans', '--color', 'never']
+      when 'clippy' then ['clippy']
       else ['build']
 
     if not @config('useCargo') or not cargoManifestPath


### PR DESCRIPTION
[Clippy](https://github.com/Manishearth/rust-clippy) is a powerful linter for Rust with some really usefull warnings. This PR allows `rust-linter` to lint code through [`cargo-clippy`](https://github.com/White-Oak/cargo-clippy) subcommand (similar to `cargo-check`). `cargo-clippy` should be installed (via `cargo install`) to use it.