### PR TITLE
Add config for using multirust for clippy

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -6,6 +6,10 @@ module.exports =
       type: 'boolean'
       default: true
       description: "Use Cargo if it's possible"
+    useMultirustForClippy:
+      type: 'boolean'
+      default: true
+      description: "Use multirust for clippy"
     rustcPath:
       type: 'string'
       default: 'rustc'
@@ -24,7 +28,7 @@ module.exports =
       enum: ['build', 'check', 'test', 'rustc', 'clippy']
       description: "Use 'check' for fast linting (you need to install
         `cargo-check`). Use 'clippy' to increase amount of available lints
-        (you need to install `cargo-clippy`). 
+        (you need to install `cargo-clippy`).
         Use 'test' to lint test code, too.
         Use 'rustc' for fast linting (note: does not build
         the project)."

--- a/lib/linter-rust.coffee
+++ b/lib/linter-rust.coffee
@@ -121,13 +121,9 @@ class LinterRust
 
 
    buildCargoPath: (cargoPath) =>
-     if (@config 'cargoCommand') == 'clippy' and @usingMultirustForClippy
+     if (@config 'cargoCommand') == 'clippy' and @config 'useMultirustForClippy'
        return ['multirust','run', 'nightly', 'cargo']
      else
        return [cargoPath]
-
-   usingMultirustForClippy: () =>
-     result = spawn.spawnSync 'multirust', ['--version']
-     return result.status == 0
 
 module.exports = LinterRust


### PR DESCRIPTION
The autodetect code causes Atom to pop up an error dialog every time
if multirust isn't installed.

Alternatively the autodetect code could be improved, but I don't know
of a good cross-platform way of doing it.