### PR TITLE
Added fallback to cargo for clippy if multirust isn't available

### DIFF
--- a/lib/linter-rust.coffee
+++ b/lib/linter-rust.coffee
@@ -143,13 +143,16 @@ class LinterRust
 
 
    buildCargoPath: (cargoPath) =>
-     if (@config 'cargoCommand') == 'clippy' and @usingMultirustForClippy
+     if (@config 'cargoCommand') == 'clippy' and @usingMultirustForClippy()
        return ['multirust','run', 'nightly', 'cargo']
      else
        return [cargoPath]
 
    usingMultirustForClippy: () =>
-     result = spawn.spawnSync 'multirust', ['--version']
-     return result.status == 0
+     try
+       result = spawn.execSync 'multirust --version'
+       return result.status == 0
+     catch
+       return false
 
 module.exports = LinterRust


### PR DESCRIPTION
Fixes issue mentioned by @mninja in #46:

> Unfortunately Atom now will display Failed to run multirust: spawn multirust ENOENT every single time if multirust isn't installed. It would make more sense to use an option instead of that autodetect, or perhaps detect in a way that doesn't pop up an error.

@mninja also tried to fix this in #53 by adding a separate option, but I instead improved autodetection code with try/catch that handles missing multirust just fine and tries to fallback to cargo.