### PR TITLE
Fixed undesirable modification of global objects

### DIFF
--- a/lib/linter-rust.coffee
+++ b/lib/linter-rust.coffee
@@ -19,7 +19,7 @@ class LinterRust
       file = @initCmd do textEditor.getPath
       curDir = path.dirname file
       PATH = path.dirname @cmd[0]
-      options = process.env
+      options = JSON.parse JSON.stringify process.env
       options.PATH = PATH + path.delimiter + options.PATH
       options.cwd = curDir
       @cmd.push file


### PR DESCRIPTION
The modification of the env vars had undesirable side effects on Windows, breaking multiple other packages at random times.

I think it goes without saying that `process.env` should not be modified at runtime.