### PR TITLE
Trim whitespace from rustc and cargo paths (helps #41)

### DIFF
--- a/lib/linter-rust.coffee
+++ b/lib/linter-rust.coffee
@@ -105,11 +105,11 @@ class LinterRust
 
   initCmd: (editingFile) =>
     cargoManifestPath = @locateCargo path.dirname editingFile
-    rustcPath = @config 'rustcPath'
+    rustcPath = (@config 'rustcPath').trim()
     rustcArgs = switch @config 'rustcBuildTest'
       when true then ['--cfg', 'test', '-Z', 'no-trans', '--color', 'never']
       else ['-Z', 'no-trans', '--color', 'never']
-    cargoPath = @config 'cargoPath'
+    cargoPath = (@config 'cargoPath').trim()
     cargoArgs = switch @config 'cargoCommand'
       when 'check' then ['check']
       when 'test' then ['test', '--no-run']

--- a/spec/parse-spec.coffee
+++ b/spec/parse-spec.coffee
@@ -68,3 +68,16 @@ describe "LinterRust::parse", ->
     multi = linter.parse('a:1:2: 3:4 error: a\n\rb\n\rx:1:2: 3:4 error: asd\r\n')
     expect(multi[0].text).toEqual('a\n\rb')
     expect(multi[1].text).toEqual('asd')
+
+  it "should not throw an error with extra whitespace in paths", ->
+    buildLinterWithWhitespacePath = () ->
+      atom.config.set "linter-rust.rustc", "rustc\n"
+      atom.config.set "linter-rust.cargo", "cargo\n"
+      new LinterRust()
+
+    resetPath = () ->
+      atom.config.set "linter-rust.rustc", "rustc"
+      atom.config.set "linter-rust.cargo", "cargo"
+
+    expect(buildLinterWithWhitespacePath).not.toThrow()
+    resetPath()


### PR DESCRIPTION
I figured out the problem I was having in #41: I had used `pbcopy` to grab the location of the item after using `which` to look it up (to make sure I didn't mistype it), so:

```sh
$ which cargo | pbcopy
```

Unfortunately, this ended up copying in a newline. And that made `child_process.spawn()` *extremely* unhappy. The fix was simply to make sure that the paths were trimmed of extra whitespace, and I also added a test to make sure this doesn't come up again in the future.

I'm not marking this as *resolving* the original issue, because I don't know that it actually does for all scenarios. I do know it fixed one bug, though!