### PR TITLE
Added support for JSON error output of rustc

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -24,7 +24,7 @@ module.exports =
       enum: ['build', 'check', 'test', 'rustc', 'clippy']
       description: "Use 'check' for fast linting (you need to install
         `cargo-check`). Use 'clippy' to increase amount of available lints
-        (you need to install `cargo-clippy`).
+        (you need to install `clippy`).
         Use 'test' to lint test code, too.
         Use 'rustc' for fast linting (note: does not build
         the project)."


### PR DESCRIPTION
Code checks if a nightly rustc of date later than at least '2016-08-08'  is present to enable JSON output support. Eventually, stable versions od rust will support this feature as well.

This fixes #62.