### PR TITLE
Fix for https://github.com/AtomLinter/linter-rust/issues/70

### DIFF
--- a/lib/linter-rust.coffee
+++ b/lib/linter-rust.coffee
@@ -215,7 +215,7 @@ class LinterRust
 
   ableToJSONErrors: () =>
     rustcPath = (@config 'rustcPath').trim()
-    result = spawn.execSync rustcPath + ' --version'
+    result = spawn.execSync rustcPath + ' --version', {stdio: 'pipe' }
     match = XRegExp.exec result, @patternRustcVersion
     return match and match.nightly and match.date > '2016-08-08'
 


### PR DESCRIPTION
This fixed [issue 70](https://github.com/AtomLinter/linter-rust/issues/70) for me and for (idan-weizman) on Windows 10 anniversary update with Atom 1.9.9. This isn't tested on Linux and macOS, though. 

Thanks to [idan-weizman](https://github.com/idan-weizman) for finding the solution!