### PR TITLE
Assume non-nightly versions >= 1.12.0 also support JSON errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "atom-package-deps": "^4.3.0",
+    "semver": "^5.3.0",
     "xregexp": "~3.1.0"
   },
   "package-deps": [


### PR DESCRIPTION
This pull request fixes method `ableToJSONErrors` that checks whether rustc is able to output errors in the new JSON format. Previously this check assumed that only nightly builds after 2016-08-08 supported the new format. Now that 1.12.0 is released we can also assume that release builds with version number >= 1.12.0 also support JSON output.

These changes add the [semver](https://www.npmjs.com/package/semver) package as a dependency.

Fixes #78.