### PR TITLE
Fix span for (some) nested macro invocations.

### DIFF
--- a/lib/mode.coffee
+++ b/lib/mode.coffee
@@ -37,7 +37,7 @@ parseJsonMessages = (messages, {disabledWarnings}) ->
     continue unless input and input.spans
     primary_span = input.spans.find (span) -> span.is_primary
     continue unless primary_span
-    if primary_span.expansion && primary_span.expansion.span
+    while primary_span.expansion and primary_span.expansion.span
       primary_span = primary_span.expansion.span
     range = [
       [primary_span.line_start - 1, primary_span.column_start - 1],


### PR DESCRIPTION
Errors in some nested macro invocations were not showing the span in the
correct place.

Example code:

```
#[derive(PartialEq)]
struct Foo;

fn main() {
    assert_eq!(Foo, Foo);
}
```

Instead of showing the error in line 5, it shows the following error:

```
the trait bound `Foo: std::fmt::Debug` is not satisfied at line 9 col 3 in <std macros>
```

<hr>

Before:

![screen shot 2016-10-30 at 11 18 24 am](https://cloud.githubusercontent.com/assets/217126/19834783/179c3646-9e94-11e6-9433-2e5c37494c1c.png)

After:

![screen shot 2016-10-30 at 11 19 40 am](https://cloud.githubusercontent.com/assets/217126/19834784/19c83938-9e94-11e6-82ba-a79e58b36010.png)
