### PR TITLE
Re-work the CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,41 @@
-language: objective-c
+### Project specific config ###
+language: rust
+
+matrix:
+  include:
+    - os: linux
+      env: ATOM_CHANNEL=stable
+      rust: stable
+
+    - os: linux
+      env: ATOM_CHANNEL=beta
+      rust: beta
+
+### Generic setup follows ###
+script:
+  - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
+  - chmod u+x build-package.sh
+  - ./build-package.sh
 
 notifications:
   email:
     on_success: never
     on_failure: change
 
-script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
+branches:
+  only:
+    - master
+    - /^greenkeeper/.*$/
 
+git:
+  depth: 10
+
+sudo: false
+
+addons:
+  apt:
+    packages:
+    - build-essential
+    - git
+    - libgnome-keyring-dev
+    - fakeroot


### PR DESCRIPTION
* Bring the configuration up to date with the current atom/ci recommendations
* Move to Travis-CI's predefined Rust language VM
* Whitelist all Greenkeeper builds for proper dependency testing