### PR TITLE
Allow disabling execution timeout

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -53,7 +53,11 @@ module.exports =
       type: 'boolean'
       default: true
       description: "Uncheck this if you need to change toolchains during one Atom session. Otherwise toolchains' versions are saved for an entire Atom session to increase performance."
-
+    disableExecTimeout:
+      title: "Disable Execution Timeout"
+      type: 'boolean'
+      default: false
+      description: "By default processes running longer than 10 seconds will be automatically terminated. Enable this option if you are getting messages about process execution timing out."
 
   activate: ->
     require('atom-package-deps').install 'linter-rust'


### PR DESCRIPTION
Add an option that when enabled turns off the default execution timeout of 10 seconds. Defaults to false as this is generally a bad idea in case a process gets stuck and should only be enabled if you regularly work on large projects.

Fixes #103.