### PR TITLE
Fix clippy `--manifest-path` usage

### DIFF
--- a/lib/mode.coffee
+++ b/lib/mode.coffee
@@ -186,7 +186,7 @@ buildCargoArguments = (linter, cargoManifestPath) ->
       .concat cargoArgs
       .concat ['-j', linter.jobsNumber]
     cmd = cmd.concat compilationFeatures if compilationFeatures
-    cmd = cmd.concat ['--manifest-path', cargoManifestPath]
+    cmd.push "--manifest-path=#{cargoManifestPath}"
     [cargoManifestPath, cmd]
 
 # These define the behabiour of each error mode linter-rust has


### PR DESCRIPTION
Restores clippy usage ability by adopting `--manifest-path=PATH` syntax over `--manifest-path PATH`.

Fixes  #114