### PR TITLE
add --tests flag to `check all` mode

### DIFF
--- a/lib/mode.coffee
+++ b/lib/mode.coffee
@@ -175,7 +175,7 @@ buildCargoArguments = (linter, cargoManifestPath) ->
 
   cargoArgs = switch linter.cargoCommand
     when 'check' then ['check']
-    when 'check all' then ['check', '--all']
+    when 'check all' then ['check', '--all', '--tests']
     when 'test' then ['test', '--no-run']
     when 'rustc' then ['rustc', '--color', 'never']
     when 'clippy' then ['clippy']


### PR DESCRIPTION
though current description says it lints tests,
`check all` mode only checks integration tests under `tests` directory
and doesn't check unit tests like `#[test] test_foo() { ... }`
this commit just fix this inconsistency