### PR TITLE
Fix 'check all' and Add 'test all'

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -17,7 +17,7 @@ module.exports =
     cargoCommand:
       type: 'string'
       default: 'check all'
-      enum: ['build', 'check', 'check all', 'test', 'rustc', 'clippy']
+      enum: ['build', 'check', 'check all', 'test', 'test all', 'rustc', 'clippy']
       description: "Use 'check' for fast linting.
         Use 'check all' for fast linting of all packages and tests.
         Use 'clippy' to increase amount of available lints

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -16,7 +16,7 @@ module.exports =
       description: "Path to Rust's package manager `cargo`"
     cargoCommand:
       type: 'string'
-      default: 'check all'
+      default: 'test all'
       enum: ['build', 'check', 'check all', 'test', 'test all', 'rustc', 'clippy']
       description: "Use 'check' for fast linting.
         Use 'check all' for fast linting of all packages and tests.

--- a/lib/mode.coffee
+++ b/lib/mode.coffee
@@ -175,8 +175,9 @@ buildCargoArguments = (linter, cargoManifestPath) ->
 
   cargoArgs = switch linter.cargoCommand
     when 'check' then ['check']
-    when 'check all' then ['check', '--all', '--tests']
+    when 'check all' then ['check', '--all']
     when 'test' then ['test', '--no-run']
+    when 'test all' then ['test', '--no-run', '--all']
     when 'rustc' then ['rustc', '--color', 'never']
     when 'clippy' then ['clippy']
     else ['build']


### PR DESCRIPTION
To resolve #120 

- Fix `check all`: `--tests` option only includes `tests/` directory.
- Add `test all`: We expected `check` to check tests in source files, but it doesn't.
If we want to check tests, we need `test --no-run` instead of `check`.

Edit:
I changed `test all` option default because it can check everything.