### PR TITLE
ci: fix deployment scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,33 @@
 ### Project specific config ###
 language: rust
+rust: stable
+os: linux
 
-matrix:
+env:
+  matrix:
+    - ATOM_CHANNEL=stable
+    - ATOM_CHANNEL=beta
+
+script:
+  - commitlint-travis
+
+jobs:
   include:
-    - os: linux
-      env: ATOM_CHANNEL=stable
-      rust: stable
-
-    - os: linux
-      env: ATOM_CHANNEL=beta
-      rust: beta
+    - stage: release
+      script:
+        - export PATH=${PATH}:${HOME}/atom/usr/bin/
+      deploy:
+        provider: script
+        skip_cleanup: true
+        script:
+          - nvm install lts/*
+          - npx semantic-release
 
 ### Generic setup follows ###
-script:
+install:
   - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
   - chmod u+x build-package.sh
-  - ./build-package.sh
+  - "./build-package.sh"
 
 notifications:
   email:
@@ -25,11 +37,12 @@ notifications:
 branches:
   only:
     - master
-    - /^greenkeeper/.*$/
+    - "/^greenkeeper/.*$/"
 
 git:
   depth: 10
 
+dist: trusty
 sudo: false
 
 addons:
@@ -40,14 +53,7 @@ addons:
     - libgnome-keyring-dev
     - fakeroot
 
-node_js: lts/*
-
-after_success:
-  # Add apm to the PATH
-  - export PATH=${PATH}:${HOME}/atom/usr/bin/
-
-deploy:
-  provider: script
-  skip_cleanup: true
-  script:
-    - npx semantic-release
+stages:
+  - test
+  - name: release
+    if: (NOT type = pull_request) AND branch = master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,30 @@
 ### Project specific config ###
-language: rust
-rust: stable
 os: linux
-
-env:
-  matrix:
-    - ATOM_CHANNEL=stable
-    - ATOM_CHANNEL=beta
-
-script:
-  - commitlint-travis
 
 jobs:
   include:
+    - stage: test
+      language: rust
+      rust: stable
+      env: ATOM_CHANNEL=stable
+      script: skip
+    - stage: test
+      language: rust
+      rust: beta
+      env: ATOM_CHANNEL=beta
+      script: skip
+    - stage: test
+      language: node_js
+      node_js: lts/*
+      install:
+        - npm install
+      script:
+        - commitlint-travis
     - stage: release
+      # Since the deploy needs APM, currently the simplest method is to run
+      # build-package.sh, which requires the specs to pass, so this must run on Rust
+      language: rust
+      rust: stable
       script:
         - export PATH=${PATH}:${HOME}/atom/usr/bin/
       deploy:

--- a/package.json
+++ b/package.json
@@ -3,10 +3,13 @@
   "main": "./lib/init",
   "version": "0.8.4",
   "description": "Lint Rust-files, using rustc and/or cargo",
-  "repository": "https://github.com/AtomLinter/linter-rust",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AtomLinter/linter-rust.git"
+  },
   "license": "MIT",
   "engines": {
-    "atom": ">0.50.0"
+    "atom": ">=1.0.0 <2.0.0"
   },
   "providedServices": {
     "linter": {


### PR DESCRIPTION
Use build stages to only run the deployment script when running on master. Ensure that the latest LTS release of Node.js is installed in the deployment build before attempting to run it, and add `commitlint` to the test stage to ensure commit messages are linted.

_Note: The required CI environment variables have been added to the settings for Travis CI._

Completes the changes that should have been incorporated into #129 before merging.