### PR TITLE
fix(package): update xregexp to version 4.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "atom-linter": "^10.0.0",
     "atom-package-deps": "^4.3.1",
     "semver": "^5.3.0",
-    "xregexp": "^3.1.1"
+    "xregexp": "^4.1.1"
   },
   "package-deps": [
     "linter",


### PR DESCRIPTION
The relevant [breaking changes](https://github.com/slevithan/xregexp/releases/tag/v4.0.0) don't appear to affect this package.

Closes #124.