### PR TITLE
Add option for `cargo check --tests`

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -17,15 +17,27 @@ module.exports =
     cargoCommand:
       type: 'string'
       default: 'test all'
-      enum: ['build', 'check', 'check all', 'test', 'test all', 'rustc', 'clippy']
-      description: "Use 'check' for fast linting.
-        Use 'check all' for fast linting of all packages.
-        Use 'clippy' to increase amount of available lints
-        (you need to install `clippy`).
-        Use 'test' to lint test code, too.
-        Use 'test all' to lint test code in all packages, too.
-        Use 'rustc' for fast linting (note: does not build
-        the project)."
+      enum: [
+          'build'
+          'check'
+          'check all'
+          'check tests'
+          'test'
+          'test all'
+          'rustc'
+          'clippy'
+      ]
+      description:
+      """
+      - Use `build` to simply compile the code.
+      - Use `check` for fast linting.
+      - Use `check all` for fast linting of all packages in the project.
+      - Use `check tests` to also include `#[cfg(test)]` code in linting.
+      - Use 'clippy' to increase amount of available lints (you need to install `clippy`).
+      - Use 'test' to run tests.
+      - Use 'test all' run tests for all packages in the project.
+      - Use 'rustc' for linting in Rust pre-1.23.
+      """
     cargoManifestFilename:
       type: 'string'
       default: 'Cargo.toml'

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -33,7 +33,7 @@ module.exports =
       <li>Use **check all** for fast linting of all packages in the project.</li>
       <li>Use **check tests** to also include \`#[cfg(test)]\` code in linting.</li>
       <li>Use **clippy** to increase amount of available lints (you need to install \`clippy\`).</li>
-      <li>Use **test** to run tests (successful tests may lints from showing).</li>
+      <li>Use **test** to run tests (note that once the tests are built, lints stop showing).</li>
       <li>Use **test all** run tests for all packages in the project.</li>
       <li>Use **rustc** for linting with Rust pre-1.23.</li>
       </ul>"""#.replace('\n', '<br>')

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -36,7 +36,7 @@ module.exports =
       <li>Use **test** to run tests (note that once the tests are built, lints stop showing).</li>
       <li>Use **test all** run tests for all packages in the project.</li>
       <li>Use **rustc** for linting with Rust pre-1.23.</li>
-      </ul>"""#.replace('\n', '<br>')
+      </ul>"""
     cargoManifestFilename:
       type: 'string'
       default: 'Cargo.toml'

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -34,7 +34,7 @@ module.exports =
       - Use `check all` for fast linting of all packages in the project.
       - Use `check tests` to also include `#[cfg(test)]` code in linting.
       - Use 'clippy' to increase amount of available lints (you need to install `clippy`).
-      - Use 'test' to run tests.
+      - Use 'test' to run tests (successful tests may lints from showing).
       - Use 'test all' run tests for all packages in the project.
       - Use 'rustc' for linting in Rust pre-1.23.
       """

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -18,26 +18,25 @@ module.exports =
       type: 'string'
       default: 'test all'
       enum: [
-          'build'
-          'check'
-          'check all'
-          'check tests'
-          'test'
-          'test all'
-          'rustc'
-          'clippy'
+        'build'
+        'check'
+        'check all'
+        'check tests'
+        'test'
+        'test all'
+        'rustc'
+        'clippy'
       ]
-      description:
-      """
-      - Use `build` to simply compile the code.
-      - Use `check` for fast linting.
-      - Use `check all` for fast linting of all packages in the project.
-      - Use `check tests` to also include `#[cfg(test)]` code in linting.
-      - Use 'clippy' to increase amount of available lints (you need to install `clippy`).
-      - Use 'test' to run tests (successful tests may lints from showing).
-      - Use 'test all' run tests for all packages in the project.
-      - Use 'rustc' for linting in Rust pre-1.23.
-      """
+      description: """`cargo` command to run.<ul>
+      <li>Use **build** to simply compile the code.</li>
+      <li>Use **check** for fast linting (does not build the project).</li>
+      <li>Use **check all** for fast linting of all packages in the project.</li>
+      <li>Use **check tests** to also include \`#[cfg(test)]\` code in linting.</li>
+      <li>Use **clippy** to increase amount of available lints (you need to install \`clippy\`).</li>
+      <li>Use **test** to run tests (successful tests may lints from showing).</li>
+      <li>Use **test all** run tests for all packages in the project.</li>
+      <li>Use **rustc** for linting with Rust pre-1.23.</li>
+      </ul>"""#.replace('\n', '<br>')
     cargoManifestFilename:
       type: 'string'
       default: 'Cargo.toml'

--- a/lib/mode.coffee
+++ b/lib/mode.coffee
@@ -176,6 +176,7 @@ buildCargoArguments = (linter, cargoManifestPath) ->
   cargoArgs = switch linter.cargoCommand
     when 'check' then ['check']
     when 'check all' then ['check', '--all']
+    when 'check tests' then ['check', '--tests']
     when 'test' then ['test', '--no-run']
     when 'test all' then ['test', '--no-run', '--all']
     when 'rustc' then ['rustc', '--color', 'never']


### PR DESCRIPTION
- Add `check tests` option to `cargoCommand` which runs `cargo check --tests`. This provides linting on `#[cfg(test)]` code without running the tests.
- Improve the description of the available commands by converting into a list.
- Add a note that running `cargo test` stops lints from appearing
- Add a note in the description that `rustc` is for older Rust versions.

I had been wanting my tests to be linted, and I noticed that when linting with `cargo test`, `cargo` was omitting the lints after the tests were compiled. I've added this command to allow better usage of the linter for code which has tests in it.