### PR TITLE
Update to Linter v2

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -75,7 +75,6 @@ module.exports =
   activate: ->
     require('atom-package-deps').install 'linter-rust'
 
-
   provideLinter: ->
     LinterRust = require('./linter-rust')
     @provider = new LinterRust()
@@ -84,5 +83,5 @@ module.exports =
       grammarScopes: ['source.rust']
       scope: 'project'
       lint: @provider.lint
-      lintOnFly: false
+      lintsOnChange: false
     }

--- a/lib/linter-rust.coffee
+++ b/lib/linter-rust.coffee
@@ -115,8 +115,8 @@ class LinterRust
 
             # correct file paths
             messages.forEach (message) ->
-              if !(path.isAbsolute message.filePath)
-                message.filePath = path.join curDir, message.filePath
+              if !(path.isAbsolute message.location.file)
+                message.file = path.join curDir, message.file
             messages
           else
             # whoops, we're in trouble -- let's output as much as we can
@@ -195,7 +195,6 @@ class LinterRust
       .then (result) =>
         @cachedErrorMode = result
         result
-
 
   locateCargo: (curDir) =>
     root_dir = if /^win/.test process.platform then /^.:\\$/ else /^\/$/

--- a/package.json
+++ b/package.json
@@ -14,18 +14,18 @@
   "providedServices": {
     "linter": {
       "versions": {
-        "1.0.0": "provideLinter"
+        "2.0.0": "provideLinter"
       }
     }
   },
   "dependencies": {
     "atom-linter": "^10.0.0",
-    "atom-package-deps": "^4.3.1",
+    "atom-package-deps": "^5.0.0",
     "semver": "^5.3.0",
     "xregexp": "^4.1.1"
   },
   "package-deps": [
-    "linter",
+    "linter:2.0.0",
     "language-rust"
   ]
 }


### PR DESCRIPTION
Update to the Linter v2 API, allowing this provider to continue working with newer versions of Linter.

Fixes #142.