### PR TITLE
Remove the dependency on language-rust

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "license": "MIT",
   "engines": {
-    "atom": ">=1.0.0 <2.0.0"
+    "atom": ">=1.33.0 <2.0.0"
   },
   "providedServices": {
     "linter": {
@@ -25,7 +25,6 @@
     "xregexp": "^4.1.1"
   },
   "package-deps": [
-    "linter:2.0.0",
-    "language-rust"
+    "linter:2.0.0"
   ]
 }


### PR DESCRIPTION
As of v1.33.0 Atom has built in support for the Rust language, meaning the `language-rust` package is no longer required in order for Atom to support this language.