### PR TITLE
Improve workspace handelling

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -26,6 +26,7 @@ module.exports =
         'test all'
         'rustc'
         'clippy'
+        'clippy all'
       ]
       description: """`cargo` command to run.<ul>
       <li>Use **build** to simply compile the code.</li>
@@ -33,6 +34,7 @@ module.exports =
       <li>Use **check all** for fast linting of all packages in the project.</li>
       <li>Use **check tests** to also include \`#[cfg(test)]\` code in linting.</li>
       <li>Use **clippy** to increase amount of available lints (you need to install \`clippy\`).</li>
+      <li>Use **clippy all** to increase amount of available lints (you need to install \`clippy\`) for all packages in the project.</li>
       <li>Use **test** to run tests (note that once the tests are built, lints stop showing).</li>
       <li>Use **test all** run tests for all packages in the project.</li>
       <li>Use **rustc** for linting with Rust pre-1.23.</li>

--- a/lib/mode.coffee
+++ b/lib/mode.coffee
@@ -175,10 +175,10 @@ buildCargoArguments = (linter, cargoManifestPath) ->
 
   cargoArgs = switch linter.cargoCommand
     when 'check' then ['check']
-    when 'check all' then ['check', '--all']
+    when 'check all' then ['check', '--all', '--all-targets']
     when 'check tests' then ['check', '--tests']
     when 'test' then ['test', '--no-run']
-    when 'test all' then ['test', '--no-run', '--all']
+    when 'test all' then ['test', '--no-run', '--all', '--all-targets']
     when 'rustc' then ['rustc', '--color', 'never']
     when 'clippy' then ['clippy']
     when 'clippy all' then ['clippy', '--workspace', '--all-targets']

--- a/lib/mode.coffee
+++ b/lib/mode.coffee
@@ -165,7 +165,7 @@ buildCargoArguments = (linter, cargoManifestPath) ->
               .catch ->
                 result: false
       usingMultitoolForClippy.then (canUseMultirust) ->
-        if cargoCommand == 'clippy' and canUseMultirust.result
+        if (cargoCommand == 'clippy' or cargoCommand == 'clippy all') and canUseMultirust.result
           [canUseMultirust.tool, 'run', 'nightly', 'cargo']
         else
           [cargoPath]
@@ -181,6 +181,7 @@ buildCargoArguments = (linter, cargoManifestPath) ->
     when 'test all' then ['test', '--no-run', '--all']
     when 'rustc' then ['rustc', '--color', 'never']
     when 'clippy' then ['clippy']
+    when 'clippy all' then ['clippy', '--workspace', '--all-targets']
     else ['build']
 
   compilationFeatures = linter.compilationFeatures(true)


### PR DESCRIPTION
I was having issues with this in my workspace projects so I went and fixed that

Additions
- Use `cargo locate-project --workspace` to find workspace manifiest
- Add `cargo all` which checks all workspaces and all targets
- Fix issue with paths relative to the cargo manifest root not cwd
- Adds the `--all-targets` option to the `all` varients so that it checks all binaries/examples/tests/benches

---
Issues related to worskspaces
Fixes #151

---
Issues related to `--all-targets`
Fixes #61
Fixes #111 (In terms of `--all-targets` checking all examples and tests)
Fixes #113